### PR TITLE
Integrate plugin-update-checker v5 and update plugin bootstrap

### DIFF
--- a/livechat-ai.php
+++ b/livechat-ai.php
@@ -9,13 +9,6 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-require_once __DIR__ . '/vendor/plugin-update-checker/plugin-update-checker.php';
-Puc_v4_Factory::buildUpdateChecker(
-    'https://github.com/<gebruikersnaam>/23rf-livechat-wp-ai',
-    __FILE__,
-    'livechat-ai'
-);
-
 class LiveChatAI {
     const WEBHOOK_URL = 'https://example.com/webhook'; // vervang met jouw webhook
 
@@ -67,5 +60,14 @@ class LiveChatAI {
         wp_send_json_success( [ 'reply' => $body ] );
     }
 }
+
+if ( ! class_exists( 'Puc_v5_Factory', false ) ) {
+    require __DIR__ . '/vendor/plugin-update-checker/plugin-update-checker.php';
+}
+Puc_v5_Factory::buildUpdateChecker(
+    'https://github.com/<username>/23rf-livechat-wp-ai',
+    __FILE__,
+    'livechat-ai'
+);
 
 new LiveChatAI();

--- a/vendor/plugin-update-checker/plugin-update-checker.php
+++ b/vendor/plugin-update-checker/plugin-update-checker.php
@@ -1,30 +1,30 @@
 <?php
-// Minimal stub of YahnisElsts/plugin-update-checker for offline environments.
-// This is not the full library; it only defines the classes required
-// to prevent fatal errors when integrating the update checker.
+// Minimal stub of YahnisElsts/plugin-update-checker v5 for offline environments.
+// Provides the classes needed to prevent fatal errors when integrating the update checker.
 
-if (!class_exists('Puc_v4_Factory')) {
-    class Puc_v4_Factory {
-        public static function buildUpdateChecker($metadataUrl, $pluginFile, $slug = null, $checkPeriod = 12, $optionName = '', $muPluginFile = '') {
-            return new Puc_v4_UpdateChecker($metadataUrl, $pluginFile, $slug, $checkPeriod, $optionName, $muPluginFile);
+if ( ! class_exists( 'Puc_v5_Factory' ) ) {
+    class Puc_v5_Factory {
+        public static function buildUpdateChecker( $metadataUrl, $pluginFile, $slug = null, $checkPeriod = 12, $optionName = '', $muPluginFile = '' ) {
+            return new Puc_v5_UpdateChecker( $metadataUrl, $pluginFile, $slug, $checkPeriod, $optionName, $muPluginFile );
         }
     }
 }
 
-if (!class_exists('Puc_v4_UpdateChecker')) {
-    class Puc_v4_UpdateChecker {
+if ( ! class_exists( 'Puc_v5_UpdateChecker' ) ) {
+    class Puc_v5_UpdateChecker {
         protected $metadataUrl;
         protected $pluginFile;
         protected $slug;
 
-        public function __construct($metadataUrl, $pluginFile, $slug = null, $checkPeriod = 12, $optionName = '', $muPluginFile = '') {
+        public function __construct( $metadataUrl, $pluginFile, $slug = null, $checkPeriod = 12, $optionName = '', $muPluginFile = '' ) {
             $this->metadataUrl = $metadataUrl;
-            $this->pluginFile = $pluginFile;
-            $this->slug = $slug ?: plugin_basename($pluginFile);
+            $this->pluginFile  = $pluginFile;
+            $this->slug        = $slug;
         }
 
         public function checkForUpdates() {
-            // Update checking is not implemented in this stub.
+            // This is a stub and does not perform any update checking.
+            return null;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add minimal plugin-update-checker v5 stub in `vendor`
- load PUC v5 in plugin bootstrap and configure update checker

## Testing
- `php -l livechat-ai.php`
- `php -l vendor/plugin-update-checker/plugin-update-checker.php`


------
https://chatgpt.com/codex/tasks/task_e_68c15182c0e0833388ff8209b430c773