### PR TITLE
Add configurable webhook option and settings page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# LiveChat AI
+
+Een eenvoudige WordPress-plugin waarmee bezoekers via een webhook kunnen chatten met een AI-assistent.
+
+## Installatie
+1. Upload de plugin-bestanden naar de map `/wp-content/plugins/livechat-ai` of installeer de ZIP via het WordPress-beheer.
+2. Activeer de plugin via het menu **Plugins** in WordPress.
+3. Ga naar **Instellingen → LiveChat AI** en vul de webhook-URL in.
+4. Plaats de shortcode `[livechat_ai]` op een pagina of bericht waar je de chat wilt tonen.
+
+## Ontwikkeling
+- Versie: 1.0.1
+- De broncode staat op GitHub en maakt gebruik van [Plugin Update Checker](https://github.com/YahnisElsts/plugin-update-checker) voor automatische updates.
+
+## Licentie
+Dit project valt onder de MIT-licentie. Zie het bestand `LICENSE` (indien aanwezig) voor details.


### PR DESCRIPTION
## Summary
- add LiveChat AI settings page with webhook URL field
- fetch webhook from stored option with fallback
- bump plugin and asset version to 1.0.1
- document installation and usage in new README

## Testing
- `php -l livechat-ai.php`


------
https://chatgpt.com/codex/tasks/task_e_68c155f61c048333919e5cbd5f292c39